### PR TITLE
chore: add aps entitlement to fix ios notifs

### DIFF
--- a/app.json
+++ b/app.json
@@ -17,7 +17,10 @@
 			"config": {
 				"usesNonExemptEncryption": false
 			},
-			"bundleIdentifier": "com.kieranklukas.sk4ph"
+			"bundleIdentifier": "com.kieranklukas.sk4ph",
+			"entitlements": {
+				"aps-environment": "development"
+			}
 		},
 		"android": {
 			"adaptiveIcon": {


### PR DESCRIPTION
### TL;DR
Added `aps-environment` entitlement for iOS development in `app.json`.

### What changed?
Modified `app.json` to include entitlements for iOS development, specifically adding the `aps-environment` with the value `development`. This update is necessary for iOS push notification capabilities during the development phase.

### How to test?
Review the changes in `app.json` to ensure the `entitlements` key is correctly added under the `ios` configuration with `aps-environment` set to `development`.

### Why make this change?
This change is required to enable push notifications in the iOS app during development, ensuring developers can test push notifications functionality before the app is released to production.

---

