### PR TITLE
feat: pull data from local storage and not the cloud

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -147,17 +147,25 @@ export default function Home() {
 				throw new Error("Failed to upload image");
 			}
 
-			const data = await response.json();
-			console.log(data);
+			const cloudData = await response.json();
 
-			if (data.error || data.length === 0) {
+			// filter the json data from the async storage
+			const allImages = await AsyncStorage.getItem("images");
+			const cardData = JSON.parse(allImages || "[]");
+
+			if (cloudData.error || cloudData.length === 0) {
 				alert("No images found with the tag: " + query);
 				// refresh data
 				fetchData();
 				return;
 			}
 
-			setCardData(data);
+			// filter only the images that have the Cloud ID
+			const filteredData = cardData.filter((data: any) =>
+				cloudData.find((image: any) => image.id === data.cloudID)
+			);
+
+			setCardData(filteredData);
 		}, 0);
 	};
 

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -182,7 +182,6 @@ export default function Settings() {
 							"Content-Type": "application/json",
 						},
 						body: JSON.stringify({
-							uri: image.uri,
 							title: image.title,
 							tags: image.tags,
 						}),


### PR DESCRIPTION
Made a change to the way search data is displayed; instead of pulling all data for a search directly from the cloud only base that on the cloud id and link that way