### PR TITLE
bug: fix card merging error by clearing cards before reload

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -33,6 +33,7 @@ export default function Home() {
     const allImages = await AsyncStorage.getItem('images')
     if (allImages) {
       const images = JSON.parse(allImages)
+      setCardData([])
       setCardData(images)
       setFuse(new Fuse(images, { keys: ['title', 'tags'], threshold: 0.3 }))
       setRefreshing(false) // Hide refresh indicator
@@ -149,7 +150,7 @@ export default function Home() {
               <Card
                 key={index}
                 image={data.uri}
-                link={data.url ? new URL(data.url) : undefined}
+                link={data.url !== undefined ? new URL(data.url) : undefined}
                 title={data.title}
                 tags={data.tags}
                 onPress={() => removeItem(index)}


### PR DESCRIPTION
### TL;DR
Fixed a potential issue where the link could be undefined and ensured card data is reinitialized before setting new data from AsyncStorage.

### What changed?
- Added a check to verify if 'data.url' is undefined before creating a URL object
- Added reinitialization of card data array before setting the new data from AsyncStorage

### How to test?
1. Open the app and go to the Home screen
2. Pull to refresh the screen and observe any potential errors related to URL parsing
3. Ensure cards are displayed correctly and there are no issues with the link generation

### Why make this change?
To prevent potential errors or crashes due to undefined URLs and to ensure that the card data is correctly reinitialized before setting new data from AsyncStorage.

---

