### PR TITLE
feat: add menu for deleting cards

### DIFF
--- a/apps/mobile/components/card.tsx
+++ b/apps/mobile/components/card.tsx
@@ -72,26 +72,28 @@ const Card: React.FC<CardProps> = ({ image, link, title, description, tags, onPr
     <Pressable
       className="bg-slate-300 dark:bg-slate-600 rounded-lg shadow-md m-1"
       onPressIn={() => {
-        pressStart.current = Date.now()
+        if (onPress) {
+          pressStart.current = Date.now()
 
-        if (menuVisible) {
-          return
-        }
-        // animate to smaller size
-        Animated.timing(scale, {
-          toValue: 0.975,
-          duration: holdDuration * 1000,
-          useNativeDriver: true,
-        }).start(({ finished }) => {
-          // if the press was held for the duration and animation completed, set critPressed to true
-          if (finished) {
-            setCritPressed(true)
-            Haptics.selectionAsync()
+          if (menuVisible) {
+            return
           }
-        })
+          // animate to smaller size
+          Animated.timing(scale, {
+            toValue: 0.975,
+            duration: holdDuration * 1000,
+            useNativeDriver: true,
+          }).start(({ finished }) => {
+            // if the press was held for the duration and animation completed, set critPressed to true
+            if (finished) {
+              setCritPressed(true)
+              Haptics.selectionAsync()
+            }
+          })
+        }
       }}
       onPressOut={() => {
-        if (menuVisible) {
+        if (menuVisible || !onPress) {
           return
         }
         // check if the press was a long press


### PR DESCRIPTION
## TL;DR

Adds a context menu to the Card component for additional actions like opening links and deleting card.

## What changed?

- Added state to manage the visibility of the context menu.
- Introduced a TouchableOpacity to trigger the context menu.
- Updated the Card component to handle long press events to display the menu.
- Integrated Haptics for feedback when the context menu is opened.
- Added action buttons in the context menu for closing, opening links, and deletion.

## How to test?

1. Render the Card component.
2. Long press on the Card component to activate the context menu.
3. Verify that the context menu appears with the correct options.
4. Test each button to ensure it performs its expected action.

## Why make this change?

This feature improves the user experience by providing quick actions within the Card component.

---

### TL;DR
This pull request adds a new feature to mobile's `Card` component, introducing a menu with actionable buttons—'close', 'delete', and optionally 'link' or 'image' buttons. On long press, these buttons appear, allowing users to interact with the card.

### What changed?
- Imported `TouchableOpacity` and `Linking` from `react-native` and `expo-linking`, respectively.
- Introduced `menuVisible` state to manage the visibility of the actionable buttons menu.
- Updated the `onPressIn` and `onPressOut` handlers to control the appearance/disappearance of the menu.
- Added a new view that renders the buttons when `menuVisible` is `true`.

### How to test?
1. Long press a card in the mobile app to reveal the actionable buttons.
2. Ensure the buttons ('close', 'delete', 'link', 'image') appear as expected.
3. Verify that each button performs its intended action.

### Why make this change?
To enhance user interaction with the `Card` component by providing quick access to common actions such as deleting the card or following a link.

---

